### PR TITLE
chore(MusicPlayer): Add currentSong.album state relation

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -4,7 +4,9 @@
   background: $color;
   border-radius: 6px;
   border: 2px solid $color;
+  border: none;
   box-shadow: 0.5px 0.5px 4px $dark;
+  box-shadow: none;
   color: $light;
   font-family: 'Montserrat';
   font-weight: 600;

--- a/components/MusicPlayer/AlbumSelector/AlbumSelector.jsx
+++ b/components/MusicPlayer/AlbumSelector/AlbumSelector.jsx
@@ -6,7 +6,6 @@ const AlbumSelector = ({ children, albums, setCurrentAlbum, ...props }) => {
   return (
     <div className={styles.buttons}>
       <h3>Albums</h3>
-
       {/* Render a button for each album object received from albums[] */}
       {albums ? (
         albums.map(album => {

--- a/components/MusicPlayer/MusicPlayer.jsx
+++ b/components/MusicPlayer/MusicPlayer.jsx
@@ -9,7 +9,11 @@ import PlayerTracks from './PlayerTracks/PlayerTracks';
 
 const NewMusicPlayer = () => {
   const [currentAlbum, setCurrentAlbum] = useState(simulacra);
-  const [currentSong, setCurrentSong] = useState({ title: '', audio: '' });
+  const [currentSong, setCurrentSong] = useState({
+    title: '',
+    audio: '',
+    album: '',
+  });
 
   return (
     <div className={styles.player}>
@@ -21,7 +25,7 @@ const NewMusicPlayer = () => {
 
       {/* Responsive grid container for player UI */}
       <div className={styles.player_grid}>
-        <PlayerHeader currentSong={currentSong} currentAlbum={currentAlbum} />
+        <PlayerHeader currentSong={currentSong} />
 
         {/* Render audio player only when valid song is selected */}
         <PlayerAudio currentSong={currentSong} />

--- a/components/MusicPlayer/PlayerAudio/PlayerAudio.jsx
+++ b/components/MusicPlayer/PlayerAudio/PlayerAudio.jsx
@@ -13,7 +13,8 @@ const PlayerAudio = ({ currentSong, ...props }) => {
           src={currentSong.audio}
           controls
           autoPlay={true}
-          playsInline={true}>
+          playsInline={true}
+          preload>
           {/* Disclaimer if audio is blocked */}
           It looks like your browser can't play HTML5 audio! You can still get
           the music <a href={currentSong.audio}>here</a>.

--- a/components/MusicPlayer/PlayerHeader/PlayerHeader.jsx
+++ b/components/MusicPlayer/PlayerHeader/PlayerHeader.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import styles from '../MusicPlayer.module.scss';
 
-const PlayerHeader = ({ currentAlbum, currentSong }) => {
+const PlayerHeader = ({ currentSong }) => {
   return (
     <div className={styles.header}>
       {/* Show song/album for currently playing track */}
       {currentSong.title ? 'Now Playing:' : 'No song selected'}{' '}
       <span>{currentSong.title}</span>
-      {currentSong.audio && `(${currentAlbum.albumTitle})`}
+      {currentSong.audio && `(${currentSong.album})`}
     </div>
   );
 };

--- a/components/MusicPlayer/PlayerTracks/PlayerTracks.jsx
+++ b/components/MusicPlayer/PlayerTracks/PlayerTracks.jsx
@@ -20,6 +20,7 @@ const PlayerTracks = ({ currentAlbum, setCurrentSong, currentSong }) => {
               setCurrentSong({
                 title: track.trackTitle,
                 audio: track.trackAudio,
+                album: currentAlbum.albumTitle,
               })
             }>
             {track.trackNumber}. {track.trackTitle}


### PR DESCRIPTION
Adds `album` to `currentSong` state object to capture a song's parent album at the time the song is selected, and prevents the displayed album in the header's "Now Playing: Song (Album)" from changing until a new track is selected.